### PR TITLE
Add a wrapper object for the state models to enable encryption

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
+++ b/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
@@ -1,0 +1,7 @@
+package com.gu.support.workers.model
+
+/**
+ * AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
+ * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String
+ */
+case class JsonWrapper(state : String)


### PR DESCRIPTION
AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String