### PR TITLE
Cross-compile for Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared models used to interact with support step-functions.  Used by [support-wo
 Releasing to local repo
 ==================
 
-Run `sbt publishLocal`.
+Run `sbt +publishLocal`.
 
 
 Releasing to maven
@@ -16,4 +16,4 @@ Releasing to maven
 We use sbt to release to Maven. Please check notes here to ensure you are set up to release to Maven:
 https://docs.google.com/document/d/1M_MiE8qntdDn97QIRnIUci5wdVQ8_defCqpeAwoKY8g/edit#heading=h.r815791vmxv5
 
-Then run `sbt release`.
+Then run `sbt +release`.

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ organization := "com.gu"
 
 scalaVersion := "2.11.8"
 
+crossScalaVersions := Seq("2.12.2")
+
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/support-models"),
   "scm:git:git@github.com:guardian/support-models.git"
@@ -16,7 +18,7 @@ description := "Scala library to provide shared step-function models to Guardian
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "support-internationalisation" % "0.2" % "provided"
+  "com.gu" %% "support-internationalisation" % "0.4" % "provided"
 )
 
 releaseProcess := Seq[ReleaseStep](


### PR DESCRIPTION
Add cross compilation for scala 2.12.2. Also updates README to add + which triggers cross compilation

Wait for new release of support-internationalisation before merging