### PR TITLE
The FailureHandler lambda no longer needs the error object so remove it

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/ErrorState.scala
+++ b/src/main/scala/com/gu/support/workers/model/ErrorState.scala
@@ -1,3 +1,0 @@
-package com.gu.support.workers.model
-
-case class ErrorState(Error: String, Cause: String = "")

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/FailureHandlerState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/FailureHandlerState.scala
@@ -8,7 +8,6 @@ import com.gu.support.workers.model.monthlyContributions.Contribution
 case class FailureHandlerState(
   requestId: UUID,
   user: User,
-  contribution: Contribution,
-  error: ErrorState
+  contribution: Contribution
 ) extends StepFunctionUserState
 


### PR DESCRIPTION
Related to [this PR](https://github.com/guardian/support-workers/pull/37)