### PR TITLE
send acquisition events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,10 @@ description := "Scala library to provide shared step-function models to Guardian
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
+resolvers += Resolver.bintrayRepo("guardian", "ophan")
+
 libraryDependencies ++= Seq(
+  "com.gu" %% "acquisition-event-producer" % "2.0.0-SNAPSHOT",
   "com.gu" %% "support-internationalisation" % "0.5" % "provided"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.h
 resolvers += Resolver.bintrayRepo("guardian", "ophan")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer" % "2.0.0-SNAPSHOT",
+  "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.3",
   "com.gu" %% "support-internationalisation" % "0.5" % "provided"
 )
 

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields, User}
 
@@ -9,5 +10,7 @@ case class CreatePaymentMethodState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
-  paymentFields: Either[StripePaymentFields, PayPalPaymentFields]
+  paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields, User}
+import ophan.thrift.event.AbTest
 
 case class CreatePaymentMethodState(
   requestId: UUID,
@@ -12,5 +13,6 @@ case class CreatePaymentMethodState(
   contribution: Contribution,
   paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
   ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, User}
 
@@ -9,5 +10,7 @@ case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
-  paymentMethod: PaymentMethod
+  paymentMethod: PaymentMethod,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, User}
+import ophan.thrift.event.AbTest
 
 case class CreateSalesforceContactState(
   requestId: UUID,
@@ -12,5 +13,6 @@ case class CreateSalesforceContactState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
+import ophan.thrift.event.AbTest
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
@@ -13,5 +14,6 @@ case class CreateZuoraSubscriptionState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -1,17 +1,13 @@
 package com.gu.support.workers.model.monthlyContributions.state
 
-import java.util.UUID
-
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+import com.gu.support.workers.model.{PaymentMethod, User}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
 
-case class CreateZuoraSubscriptionState(
-  requestId: UUID,
+case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  salesForceContact: SalesforceContactRecord,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -3,11 +3,13 @@ package com.gu.support.workers.model.monthlyContributions.state
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.{PaymentMethod, User}
 import com.gu.support.workers.model.monthlyContributions.Contribution
+import ophan.thrift.event.AbTest
 
 case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
+import ophan.thrift.event.AbTest
 
 case class SendThankYouEmailState(
   requestId: UUID,
@@ -14,6 +15,7 @@ case class SendThankYouEmailState(
   salesForceContact: SalesforceContactRecord,
   accountNumber: String,
   ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState
 

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
 
@@ -11,6 +12,8 @@ case class SendThankYouEmailState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  accountNumber: String
+  accountNumber: String,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData
 ) extends StepFunctionUserState
 


### PR DESCRIPTION
Update and addition of models to enable the work for sending acquisition requests in [this](https://github.com/guardian/support-workers/pull/60) pull request in `support-workers`.