### PR TITLE
send acquisition events v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared models used to interact with support step-functions.  Used by [support-wo
 Releasing to local repo
 ==================
 
-Run `sbt +publishLocal`.
+Run `sbt publishLocal`.
 
 
 Releasing to maven

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ organization := "com.gu"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.11.8", "2.12.2")
-
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/support-models"),
   "scm:git:git@github.com:guardian/support-models.git"

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,10 @@ description := "Scala library to provide shared step-function models to Guardian
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
+resolvers += Resolver.bintrayRepo("guardian", "ophan")
+
 libraryDependencies ++= Seq(
+  "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.3",
   "com.gu" %% "support-internationalisation" % "0.5" % "provided"
 )
 

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -2,12 +2,17 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, User}
+import ophan.thrift.event.AbTest
 
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
-  paymentMethod: PaymentMethod
+  paymentMethod: PaymentMethod,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
@@ -2,13 +2,18 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
+import ophan.thrift.event.AbTest
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  salesForceContact: SalesforceContactRecord
+  salesForceContact: SalesforceContactRecord,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -1,17 +1,14 @@
 package com.gu.support.workers.model.monthlyContributions.state
 
-import java.util.UUID
-
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+import com.gu.support.workers.model.{PaymentMethod, User}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields, User}
 import ophan.thrift.event.AbTest
 
-case class CreatePaymentMethodState(
-  requestId: UUID,
+case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
-  paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
+  paymentMethod: PaymentMethod,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
   supportAbTests: Set[AbTest]

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -2,8 +2,10 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
+import ophan.thrift.event.AbTest
 
 case class SendThankYouEmailState(
   requestId: UUID,
@@ -11,6 +13,9 @@ case class SendThankYouEmailState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  accountNumber: String
+  accountNumber: String,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState
 


### PR DESCRIPTION
Reinstates #14 but removes Scala 2.12 as a compilation target.

It wasn't feasible to make `acquisition-event-producer` compatible with 2.12 because of its dependency on Ophan `event-model`. Eventually Ophan will be upgraded to Play 2.6, which will make it much easier to compile for 2.12 and we can add it as a target in this project again. 