### PR TITLE
Add a new parameter 'encrypted' to the JsonWrapper

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
+++ b/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
@@ -4,4 +4,4 @@ package com.gu.support.workers.model
  * AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
  * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String
  */
-case class JsonWrapper(state: String, error: Option[ExecutionError], encrypted: Boolean = false)
+case class JsonWrapper(state: String, error: Option[ExecutionError], encrypted: Boolean)

--- a/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
+++ b/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
@@ -4,4 +4,4 @@ package com.gu.support.workers.model
  * AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
  * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String
  */
-case class JsonWrapper(state: String, error: Option[ExecutionError])
+case class JsonWrapper(state: String, error: Option[ExecutionError], encrypted: Boolean = false)


### PR DESCRIPTION
This will allow us to control whether the payload is encrypted or not from one place, support-frontend rather than having to change it in two projects and then worry about synchronisation issues.

Supports PR https://github.com/guardian/support-workers/pull/62