### PR TITLE
Re-introduce sending acquisition events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared models used to interact with support step-functions.  Used by [support-wo
 Releasing to local repo
 ==================
 
-Run `sbt +publishLocal`.
+Run `sbt publishLocal`.
 
 
 Releasing to maven

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ organization := "com.gu"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.11.8", "2.12.2")
-
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/support-models"),
   "scm:git:git@github.com:guardian/support-models.git"
@@ -17,7 +15,10 @@ description := "Scala library to provide shared step-function models to Guardian
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
+resolvers += Resolver.bintrayRepo("guardian", "ophan")
+
 libraryDependencies ++= Seq(
+  "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.3",
   "com.gu" %% "support-internationalisation" % "0.5" % "provided"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.h
 resolvers += Resolver.bintrayRepo("guardian", "ophan")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.3",
+  "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.5",
   "com.gu" %% "support-internationalisation" % "0.5" % "provided"
 )
 

--- a/src/main/scala/com/gu/support/workers/model/AcquisitionData.scala
+++ b/src/main/scala/com/gu/support/workers/model/AcquisitionData.scala
@@ -6,5 +6,5 @@ import ophan.thrift.event.AbTest
 case class AcquisitionData(
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  supporterAbTest: Set[AbTest]
+  supportAbTests: Set[AbTest]
 )

--- a/src/main/scala/com/gu/support/workers/model/AcquisitionData.scala
+++ b/src/main/scala/com/gu/support/workers/model/AcquisitionData.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers.model
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import ophan.thrift.event.AbTest
 
-case class NonPaymentAcquisitionData(
+case class AcquisitionData(
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
   supporterAbTest: Set[AbTest]

--- a/src/main/scala/com/gu/support/workers/model/NonPaymentAcquisitionData.scala
+++ b/src/main/scala/com/gu/support/workers/model/NonPaymentAcquisitionData.scala
@@ -1,0 +1,10 @@
+package com.gu.support.workers.model
+
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+import ophan.thrift.event.AbTest
+
+case class NonPaymentAcquisitionData(
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supporterAbTest: Set[AbTest]
+)

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
@@ -10,5 +10,5 @@ case class CreatePaymentMethodState(
   user: User,
   contribution: Contribution,
   paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
-  nonPaymentAcquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
@@ -2,17 +2,13 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
-import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields, User}
-import ophan.thrift.event.AbTest
+import com.gu.support.workers.model.{NonPaymentAcquisitionData, PayPalPaymentFields, StripePaymentFields, User}
 
 case class CreatePaymentMethodState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
   paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
-  ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  supportAbTests: Set[AbTest]
+  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreatePaymentMethodState.scala
@@ -3,12 +3,12 @@ package com.gu.support.workers.model.monthlyContributions.state
 import java.util.UUID
 
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{NonPaymentAcquisitionData, PayPalPaymentFields, StripePaymentFields, User}
+import com.gu.support.workers.model.{AcquisitionData, PayPalPaymentFields, StripePaymentFields, User}
 
 case class CreatePaymentMethodState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
   paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
-  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
+  nonPaymentAcquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -2,12 +2,17 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, User}
+import ophan.thrift.event.AbTest
 
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
-  paymentMethod: PaymentMethod
+  paymentMethod: PaymentMethod,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -2,17 +2,13 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
-import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PaymentMethod, User}
-import ophan.thrift.event.AbTest
+import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, User}
 
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  supportAbTests: Set[AbTest]
+  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -3,12 +3,12 @@ package com.gu.support.workers.model.monthlyContributions.state
 import java.util.UUID
 
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, User}
+import com.gu.support.workers.model.{AcquisitionData, PaymentMethod, User}
 
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
+  nonPaymentAcquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateSalesforceContactState.scala
@@ -10,5 +10,5 @@ case class CreateSalesforceContactState(
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  nonPaymentAcquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
@@ -2,13 +2,18 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
+import ophan.thrift.event.AbTest
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  salesForceContact: SalesforceContactRecord
+  salesForceContact: SalesforceContactRecord,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
@@ -2,10 +2,8 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
-import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
-import ophan.thrift.event.AbTest
+import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, SalesforceContactRecord, User}
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
@@ -13,7 +11,5 @@ case class CreateZuoraSubscriptionState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  supportAbTests: Set[AbTest]
+  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers.model.monthlyContributions.state
 import java.util.UUID
 
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, SalesforceContactRecord, User}
+import com.gu.support.workers.model.{AcquisitionData, PaymentMethod, SalesforceContactRecord, User}
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
@@ -11,5 +11,5 @@ case class CreateZuoraSubscriptionState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
+  nonPaymentAcquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/CreateZuoraSubscriptionState.scala
@@ -11,5 +11,5 @@ case class CreateZuoraSubscriptionState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  nonPaymentAcquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -7,5 +7,5 @@ case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  nonPaymentAcquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -1,17 +1,14 @@
 package com.gu.support.workers.model.monthlyContributions.state
 
-import java.util.UUID
-
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+import com.gu.support.workers.model.{PaymentMethod, User}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields, User}
 import ophan.thrift.event.AbTest
 
-case class CreatePaymentMethodState(
-  requestId: UUID,
+case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
-  paymentFields: Either[StripePaymentFields, PayPalPaymentFields],
+  paymentMethod: PaymentMethod,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
   supportAbTests: Set[AbTest]

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -1,15 +1,11 @@
 package com.gu.support.workers.model.monthlyContributions.state
 
-import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
-import com.gu.support.workers.model.{PaymentMethod, User}
+import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, User}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import ophan.thrift.event.AbTest
 
 case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  supportAbTests: Set[AbTest]
+  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendAcquisitionEventState.scala
@@ -1,11 +1,11 @@
 package com.gu.support.workers.model.monthlyContributions.state
 
-import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, User}
+import com.gu.support.workers.model.{AcquisitionData, PaymentMethod, User}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 
 case class SendAcquisitionEventState(
   user: User,
   contribution: Contribution,
   paymentMethod: PaymentMethod,
-  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
+  nonPaymentAcquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers.model.monthlyContributions.state
 import java.util.UUID
 
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, SalesforceContactRecord, User}
+import com.gu.support.workers.model.{AcquisitionData, PaymentMethod, SalesforceContactRecord, User}
 
 case class SendThankYouEmailState(
   requestId: UUID,
@@ -12,6 +12,6 @@ case class SendThankYouEmailState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   accountNumber: String,
-  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
+  nonPaymentAcquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
 

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -2,8 +2,10 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
+import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
+import ophan.thrift.event.AbTest
 
 case class SendThankYouEmailState(
   requestId: UUID,
@@ -11,6 +13,9 @@ case class SendThankYouEmailState(
   contribution: Contribution,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  accountNumber: String
+  accountNumber: String,
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest]
 ) extends StepFunctionUserState
 

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -2,10 +2,8 @@ package com.gu.support.workers.model.monthlyContributions.state
 
 import java.util.UUID
 
-import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.{PaymentMethod, SalesforceContactRecord, User}
-import ophan.thrift.event.AbTest
+import com.gu.support.workers.model.{NonPaymentAcquisitionData, PaymentMethod, SalesforceContactRecord, User}
 
 case class SendThankYouEmailState(
   requestId: UUID,
@@ -14,8 +12,6 @@ case class SendThankYouEmailState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   accountNumber: String,
-  ophanIds: OphanIds,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  supportAbTests: Set[AbTest]
+  nonPaymentAcquisitionData: Option[NonPaymentAcquisitionData]
 ) extends StepFunctionUserState
 

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/state/SendThankYouEmailState.scala
@@ -12,6 +12,6 @@ case class SendThankYouEmailState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   accountNumber: String,
-  nonPaymentAcquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
 


### PR DESCRIPTION
Reverts guardian/support-models#20 and bumps acquisition event producer version.