### PR TITLE
Upgrade acquisition-event-producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.h
 resolvers += Resolver.bintrayRepo("guardian", "ophan")
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.5",
+  "com.gu" %% "acquisition-event-producer" % "2.0.1",
   "com.gu" %% "support-internationalisation" % "0.5" % "provided"
 )
 


### PR DESCRIPTION
Nothing else ise necessary here, as Fezziwig takes care of generating
encoders/decoders for the updated Thrift models.