### PR TITLE
Add an Exception Status for errors other than declined cards

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/Status.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/Status.scala
@@ -5,7 +5,7 @@ sealed trait Status {
 }
 
 object Status {
-  val all = List(Success, Failure, Pending)
+  val all = List(Success, Failure, Exception, Pending)
 
   def fromString(s: String): Option[Status] = all.find(_.asString == s)
 
@@ -15,6 +15,10 @@ object Status {
 
   case object Failure extends Status {
     override def asString = "failure"
+  }
+
+  case object Exception extends Status {
+    override def asString = "exception"
   }
 
   case object Pending extends Status {


### PR DESCRIPTION
To make it easier to see when a state machine execution has really failed due to an error rather than just due to a users card being declined I have added a new failure state to the support-workers step function.

To make use of this we need a new 'Exception' status in the CompletedState class this will mean the 'Failure' status will then only be used by payment failures.