### PR TITLE
Add a new RequestInfo object into the JsonWrapper

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
+++ b/src/main/scala/com/gu/support/workers/model/JsonWrapper.scala
@@ -4,4 +4,4 @@ package com.gu.support.workers.model
  * AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
  * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String
  */
-case class JsonWrapper(state: String, error: Option[ExecutionError], encrypted: Boolean)
+case class JsonWrapper(state: String, error: Option[ExecutionError], requestInformation: RequestInfo)

--- a/src/main/scala/com/gu/support/workers/model/RequestInfo.scala
+++ b/src/main/scala/com/gu/support/workers/model/RequestInfo.scala
@@ -1,5 +1,5 @@
 package com.gu.support.workers.model
 
 case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: List[String]){
-  def addMessage(message: String) = copy(messages = messages :+ message)
+  def appendMessage(message: String) = copy(messages = messages :+ message)
 }

--- a/src/main/scala/com/gu/support/workers/model/RequestInfo.scala
+++ b/src/main/scala/com/gu/support/workers/model/RequestInfo.scala
@@ -1,0 +1,5 @@
+package com.gu.support.workers.model
+
+case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: List[String]){
+  def addMessage(message: String) = copy(messages = messages :+ message)
+}

--- a/src/main/scala/com/gu/support/workers/model/monthlyContributions/Status.scala
+++ b/src/main/scala/com/gu/support/workers/model/monthlyContributions/Status.scala
@@ -5,7 +5,7 @@ sealed trait Status {
 }
 
 object Status {
-  val all = List(Success, Failure, Exception, Pending)
+  val all = List(Success, Failure, Pending)
 
   def fromString(s: String): Option[Status] = all.find(_.asString == s)
 
@@ -15,10 +15,6 @@ object Status {
 
   case object Failure extends Status {
     override def asString = "failure"
-  }
-
-  case object Exception extends Status {
-    override def asString = "exception"
   }
 
   case object Pending extends Status {


### PR DESCRIPTION
There is an increasing amount of metadata we need to collect for a step machine execution. Rather than adding this piecemeal into the route of the JsonWrapper object it is cleaner to encapsulate all of this within a new object `RequestInfo`. 

The `RequestInfo` class also has a message list to enable us to  capture any important debug information which might help in diagnosing failures, so that it is easily accessible without digging through log files.