### PR TITLE
Change the messages list to a mutable ListBuffer for ease of use

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/RequestInfo.scala
+++ b/src/main/scala/com/gu/support/workers/model/RequestInfo.scala
@@ -1,5 +1,10 @@
 package com.gu.support.workers.model
 
-case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: List[String]){
-  def appendMessage(message: String) = copy(messages = messages :+ message)
+import scala.collection.mutable.ListBuffer
+
+case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: ListBuffer[String] = ListBuffer.empty) {
+  def appendMessage(message: String) = {
+    messages += message
+    this
+  }
 }


### PR DESCRIPTION
Converting the messages list on the RequestInfo object into a mutable ListBuffer makes it easier to log messages for methods that are deeper in the call stack, currently each method would need to return a copy of the original object to its calling method.