### PR TITLE
Remove the Identity ID field from the StripePaymentFields class

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/PaymentFields.scala
+++ b/src/main/scala/com/gu/support/workers/model/PaymentFields.scala
@@ -4,7 +4,7 @@ sealed trait PaymentFields
 
 case class PayPalPaymentFields(baid: String) extends PaymentFields
 
-case class StripePaymentFields(userId: String, stripeToken: String) extends PaymentFields
+case class StripePaymentFields(stripeToken: String) extends PaymentFields
 
 case class DirectDebitPaymentFields(
   accountHolderName: String,


### PR DESCRIPTION
We are going to stop sending the user Identity ID as a description to Stripe for GDPR reasons. This PR removes it from the shared models.