### PR TITLE
Billing period tweaks

### DIFF
--- a/src/main/scala/com/gu/support/workers/model/BillingPeriod.scala
+++ b/src/main/scala/com/gu/support/workers/model/BillingPeriod.scala
@@ -1,14 +1,22 @@
 package com.gu.support.workers.model
 
 
-sealed trait BillingPeriod
+sealed trait BillingPeriod{
+  val noun: String
+}
 
 object BillingPeriod {
   def fromString(code: String): Option[BillingPeriod] = List(Monthly, Annual).find(_.getClass.getSimpleName == s"$code$$")
 }
 
-case object Monthly extends BillingPeriod
+case object Monthly extends BillingPeriod {
+  override val noun = "month"
+}
 
-case object Quarterly extends BillingPeriod
+case object Quarterly extends BillingPeriod {
+  override val noun = "quarter"
+}
 
-case object Annual extends BillingPeriod
+case object Annual extends BillingPeriod {
+  override val noun = "year"
+}

--- a/src/main/scala/com/gu/support/workers/model/BillingPeriod.scala
+++ b/src/main/scala/com/gu/support/workers/model/BillingPeriod.scala
@@ -1,11 +1,11 @@
 package com.gu.support.workers.model
 
 
-sealed trait BillingPeriod {
+sealed trait BillingPeriod
+
+object BillingPeriod {
   def fromString(code: String): Option[BillingPeriod] = List(Monthly, Annual).find(_.getClass.getSimpleName == s"$code$$")
 }
-
-object BillingPeriod extends BillingPeriod
 
 case object Monthly extends BillingPeriod
 

--- a/src/main/scala/com/gu/support/workers/model/User.scala
+++ b/src/main/scala/com/gu/support/workers/model/User.scala
@@ -8,9 +8,9 @@ case class User(
   firstName: String,
   lastName: String,
   country: Country,
-  state: Option[String],
-  allowMembershipMail: Boolean,
-  allowThirdPartyMail: Boolean,
-  allowGURelatedMail: Boolean,
-  isTestUser: Boolean
+  state: Option[String] = None,
+  allowMembershipMail: Boolean = false,
+  allowThirdPartyMail: Boolean = false,
+  allowGURelatedMail: Boolean = false,
+  isTestUser: Boolean = false
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.29"
+version in ThisBuild := "0.30-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.29-SNAPSHOT"
+version in ThisBuild := "0.29"


### PR DESCRIPTION
Stop the `BillingPeriod` object from extending the `BillingPeriod` trait as it is not a valid period it is just a companion object.

Add a `noun` field to `BillingPeriod` to provide a human friendly description of the period.

Provide defaults for some fields on `User` that are not used any more - it would be nice to remove them in future, but that is a bigger change.