### PR TITLE
use latest doc on maven central releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Releasing to maven
 ==================
 
 We use sbt to release to Maven. Please check notes here to ensure you are set up to release to Maven:
-https://docs.google.com/document/d/1M_MiE8qntdDn97QIRnIUci5wdVQ8_defCqpeAwoKY8g/edit#heading=h.r815791vmxv5
+https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit?usp=sharing
 
 Then run `sbt release`.


### PR DESCRIPTION
Just a quick readme update as the old doc was marked as outdated in favour of the new.

@jacobwinch 