### PR TITLE
Add unique field so that we can prevent double subscriptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,7 @@ name := "support-models"
 
 organization := "com.gu"
 
-scalaVersion := "2.11.8"
-
-crossScalaVersions := Seq(scalaVersion.value, "2.12.4")
+scalaVersion := "2.12.7"
 
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/support-models"),
@@ -21,13 +19,9 @@ resolvers += Resolver.bintrayRepo("guardian", "ophan")
 
 libraryDependencies ++= Seq(
   "com.gu" %% "support-internationalisation" % "0.9" % "provided",
-  scalaVersion {
-    case "2.11.8" => "com.gu" %% "acquisition-event-producer" % "2.0.1"
-    case "2.12.4" => "com.gu" %% "acquisition-event-producer-play26" % "4.0.3"
-  }.value
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.3"
 )
 
-releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,

--- a/src/main/scala/com/gu/support/workers/model/AccessScope.scala
+++ b/src/main/scala/com/gu/support/workers/model/AccessScope.scala
@@ -1,0 +1,25 @@
+package com.gu.support.workers.model
+
+import com.gu.support.workers.model.AccessScope.{AccessScopeByToken, AccessScopeNoRestriction, ScopeToken}
+
+sealed trait AccessScope {
+  def toOption: Option[String] = this match {
+    case AccessScopeByToken(ScopeToken(value)) => Some(value)
+    case AccessScopeNoRestriction => None
+  }
+}
+
+object AccessScope {
+
+  def fromRaw(maybeAccessScope: Option[String]): AccessScope =
+    maybeAccessScope match {
+      case Some(value) => AccessScopeByToken(ScopeToken(value))
+      case None => AccessScopeNoRestriction
+    }
+
+  case class ScopeToken(value: String) extends AnyVal
+
+  case class AccessScopeByToken(scopeToken: ScopeToken) extends AccessScope
+  case object AccessScopeNoRestriction extends AccessScope
+
+}

--- a/src/main/scala/com/gu/support/workers/model/VisitToken.scala
+++ b/src/main/scala/com/gu/support/workers/model/VisitToken.scala
@@ -1,5 +1,7 @@
 package com.gu.support.workers.model
 
-sealed trait ReadAccess
-case class ReadAccessByVisitToken(value: String) extends ReadAccess
-case object ReadAccessByIdentityId extends ReadAccess
+sealed trait AccessScopeWithinIdentityId
+case class AccessScopeByToken(scopeToken: ScopeToken) extends AccessScopeWithinIdentityId
+case object AccessScopeNoRestriction extends AccessScopeWithinIdentityId
+
+case class ScopeToken(value: String) extends AnyVal

--- a/src/main/scala/com/gu/support/workers/model/VisitToken.scala
+++ b/src/main/scala/com/gu/support/workers/model/VisitToken.scala
@@ -1,0 +1,5 @@
+package com.gu.support.workers.model
+
+sealed trait ReadAccess
+case class ReadAccessByVisitToken(value: String) extends ReadAccess
+case object ReadAccessByIdentityId extends ReadAccess

--- a/src/main/scala/com/gu/support/workers/model/VisitToken.scala
+++ b/src/main/scala/com/gu/support/workers/model/VisitToken.scala
@@ -1,7 +1,0 @@
-package com.gu.support.workers.model
-
-sealed trait AccessScopeWithinIdentityId
-case class AccessScopeByToken(scopeToken: ScopeToken) extends AccessScopeWithinIdentityId
-case object AccessScopeNoRestriction extends AccessScopeWithinIdentityId
-
-case class ScopeToken(value: String) extends AnyVal

--- a/src/main/scala/com/gu/support/workers/model/states/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreatePaymentMethodState.scala
@@ -10,5 +10,9 @@ case class CreatePaymentMethodState(
   product: ProductType,
   paymentFields: PaymentFields,
   acquisitionData: Option[AcquisitionData],
-  accessScopeWithinIdentityId: AccessScopeWithinIdentityId
-) extends StepFunctionUserState
+  scopeToken: Option[String]
+) extends StepFunctionUserState {
+
+  def accessScope: AccessScope = AccessScope.fromRaw(scopeToken)
+
+}

--- a/src/main/scala/com/gu/support/workers/model/states/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreatePaymentMethodState.scala
@@ -2,12 +2,13 @@ package com.gu.support.workers.model.states
 
 import java.util.UUID
 
-import com.gu.support.workers.model.{AcquisitionData, PaymentFields, ProductType, User}
+import com.gu.support.workers.model._
 
 case class CreatePaymentMethodState(
   requestId: UUID,
   user: User,
   product: ProductType,
   paymentFields: PaymentFields,
-  acquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData],
+  readAccess: ReadAccess
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/states/CreatePaymentMethodState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreatePaymentMethodState.scala
@@ -10,5 +10,5 @@ case class CreatePaymentMethodState(
   product: ProductType,
   paymentFields: PaymentFields,
   acquisitionData: Option[AcquisitionData],
-  readAccess: ReadAccess
+  accessScopeWithinIdentityId: AccessScopeWithinIdentityId
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/states/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreateSalesforceContactState.scala
@@ -10,5 +10,9 @@ case class CreateSalesforceContactState(
   product: ProductType,
   paymentMethod: PaymentMethod,
   acquisitionData: Option[AcquisitionData],
-  accessScopeWithinIdentityId: AccessScopeWithinIdentityId
-) extends StepFunctionUserState
+  scopeToken: Option[String]
+) extends StepFunctionUserState {
+
+  def accessScope: AccessScope = AccessScope.fromRaw(scopeToken)
+
+}

--- a/src/main/scala/com/gu/support/workers/model/states/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreateSalesforceContactState.scala
@@ -10,5 +10,5 @@ case class CreateSalesforceContactState(
   product: ProductType,
   paymentMethod: PaymentMethod,
   acquisitionData: Option[AcquisitionData],
-  readAccess: ReadAccess
+  accessScopeWithinIdentityId: AccessScopeWithinIdentityId
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/states/CreateSalesforceContactState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreateSalesforceContactState.scala
@@ -2,12 +2,13 @@ package com.gu.support.workers.model.states
 
 import java.util.UUID
 
-import com.gu.support.workers.model.{AcquisitionData, PaymentMethod, ProductType, User}
+import com.gu.support.workers.model._
 
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   product: ProductType,
   paymentMethod: PaymentMethod,
-  acquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData],
+  readAccess: ReadAccess
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/states/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreateZuoraSubscriptionState.scala
@@ -11,5 +11,5 @@ case class CreateZuoraSubscriptionState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   acquisitionData: Option[AcquisitionData],
-  readAccess: ReadAccess
+  accessScopeWithinIdentityId: AccessScopeWithinIdentityId
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/states/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreateZuoraSubscriptionState.scala
@@ -10,5 +10,6 @@ case class CreateZuoraSubscriptionState(
   product: ProductType,
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
-  acquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData],
+  readAccess: ReadAccess
 ) extends StepFunctionUserState

--- a/src/main/scala/com/gu/support/workers/model/states/CreateZuoraSubscriptionState.scala
+++ b/src/main/scala/com/gu/support/workers/model/states/CreateZuoraSubscriptionState.scala
@@ -11,5 +11,9 @@ case class CreateZuoraSubscriptionState(
   paymentMethod: PaymentMethod,
   salesForceContact: SalesforceContactRecord,
   acquisitionData: Option[AcquisitionData],
-  accessScopeWithinIdentityId: AccessScopeWithinIdentityId
-) extends StepFunctionUserState
+  scopeToken: Option[String]
+) extends StepFunctionUserState {
+
+  def accessScope: AccessScope = AccessScope.fromRaw(scopeToken)
+
+}


### PR DESCRIPTION
This PR adds a new field to the states so that we can prevent duplicate subscriptions being added in zuora when someone only filled in the contribute form once.

This used to be done by identity id, but if the user is not logged in or is an unverified email address, we can't use any existing information associated with the identity account.

For (a lot) more details, see https://docs.google.com/document/d/14wYvCij4pYZ-0YIY46lO4DZhL4ZfHD2max6WAyLnkpQ/edit#

I have also bumped the scala version to the latest and removed the cross build.  It seems that all users of this library are on 2.12 anyway.