### PR TITLE
Bump acquisition-event-producer to 4.0.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ resolvers += Resolver.bintrayRepo("guardian", "ophan")
 
 libraryDependencies ++= Seq(
   "com.gu" %% "support-internationalisation" % "0.9" % "provided",
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.9"
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.12"
 )
 
 releaseProcess := Seq[ReleaseStep](


### PR DESCRIPTION
To allow support-frontend to pass through data for google analytics events to support-workers lambdas

See https://github.com/guardian/acquisition-event-producer/pull/39